### PR TITLE
Update setasign/fpdi to allow greater than 1.6.* (^2.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"ext-mbstring": "*",
 
 		"psr/log": "^1.0",
-		"setasign/fpdi": "1.6.*",
+		"setasign/fpdi": "^1.6",
 		"paragonie/random_compat": "^1.4|^2.0|9.99.99",
 		"myclabs/deep-copy": "^1.7"
 


### PR DESCRIPTION
Composer.json had a minimum stability requirement of 1.6.*, need to run ^2.0 for compatibility with other dependencies (moving to PHP 7.2.9+).